### PR TITLE
Update forecast.py

### DIFF
--- a/weatherflow4py/models/rest/forecast.py
+++ b/weatherflow4py/models/rest/forecast.py
@@ -275,7 +275,7 @@ class ForecastHourly:
 
     local_day: int
     local_hour: int
-    precip: int
+    precip: float
     precip_probability: int
     # precip_type: PrecipType
     precip_type: PrecipType = field(


### PR DESCRIPTION
Proposing changing hourly forecast precip to float from int. When getting forecast data with integer, the value gets rounded up/down to 0.04 inch increments due to the unit conversion from mm.